### PR TITLE
Rename Variable from 'referrerDetails' to 'response' for Task CR-27

### DIFF
--- a/app/src/main/java/org/curiouslearning/container/firebase/AnalyticsUtils.java
+++ b/app/src/main/java/org/curiouslearning/container/firebase/AnalyticsUtils.java
@@ -59,7 +59,7 @@ public class AnalyticsUtils {
     public static void logReferrerEvent(Context context, String eventName, ReferrerDetails response) {
         if (response != null) {
             FirebaseAnalytics firebaseAnalytics = getFirebaseAnalytics(context);
-            String referrerUrl = referrerDetails.getInstallReferrer();
+            String referrerUrl = response.getInstallReferrer();
             Bundle bundle = new Bundle();
             bundle.putString("referrer_url", referrerUrl);
             bundle.putLong("referrer_click_time", response.getReferrerClickTimestampSeconds());


### PR DESCRIPTION
Fixed an issue where an incorrect variable name was used