### PR TITLE
Fix CR-193 Increase width of language dropdown and accompanying UI elements

### DIFF
--- a/app/src/main/res/layout/language_popup.xml
+++ b/app/src/main/res/layout/language_popup.xml
@@ -24,7 +24,7 @@
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/dropdown_menu"
         style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
-        android:layout_width="180dp"
+        android:layout_width="210dp"
         android:layout_height="45dp"
         android:background="@color/white"
         android:hint="@string/select"
@@ -32,7 +32,7 @@
         app:hintTextColor="@color/black"
         app:layout_constraintBottom_toBottomOf="@+id/settings_box"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.65"
+        app:layout_constraintHorizontal_bias="0.75"
         app:layout_constraintStart_toStartOf="@+id/settings_box"
         app:layout_constraintTop_toTopOf="@+id/settings_box"
         app:layout_constraintVertical_bias="0.45"


### PR DESCRIPTION
# Changes
- app/src/main/res/layout/language_popup.xml

# How to test
- Check for cape verde portuguese in dropdown should not contain "..." at end

Ref: [CR-193](https://curiouslearning.atlassian.net/jira/software/projects/CR/boards/7?selectedIssue=CR-193)


[CR-193]: https://curiouslearning.atlassian.net/browse/CR-193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ