### PR TITLE
fix: CR-295 Added user friendly message for slack marketing channel alerts

### DIFF
--- a/app/src/main/java/org/curiouslearning/container/MainActivity.java
+++ b/app/src/main/java/org/curiouslearning/container/MainActivity.java
@@ -259,13 +259,19 @@ public class MainActivity extends BaseActivity {
         String language = deferredLang.trim();
         long currentEpochTime = AnalyticsUtils.getCurrentEpochTime();
         String pseudoId = prefs.getString("pseudoId", "");
+        String[] uriParts = deepLinkUri.split("\"(?<=[?&])\"");
+        StringBuilder message = new StringBuilder();
+        message.append("An incorrect or null language value was detected in a ")
+                .append(source)
+                .append(" campaign’s deferred deep link with the following details:\n");
+        for (String part : uriParts) {
+            message.append(part).append("\n");
+        }
+        message.append("User affected:: ").append(pseudoId).append("\n")
+                .append("Detected in data at: ").append(convertEpochToDate(currentEpochTime)).append("\n")
+                .append("Alerted in Slack: ").append(convertEpochToDate(initialSlackAlertTime));
         if( language == null || language.length()==0 ){
-            SlackUtils.sendMessageToSlack(MainActivity.this, "An incorrect or null language value was detected in a "+source
-                    +" campaign’s deferred deep link with the following details: \n"
-                    + deepLinkUri + "\n"
-                    + "User affected:: " + pseudoId + "\n"
-                    + "Detected in data at: " + convertEpochToDate(currentEpochTime) + "\n"
-                    + "Alerted in Slack: " + convertEpochToDate(initialSlackAlertTime));
+            SlackUtils.sendMessageToSlack(MainActivity.this, String.valueOf(message));
             showLanguagePopup();
             return;
         }
@@ -274,12 +280,7 @@ public class MainActivity extends BaseActivity {
                     .map(String::toLowerCase)
                     .collect(Collectors.toList());
             if (lowerCaseLanguages!=null && lowerCaseLanguages.size() > 0 &&!lowerCaseLanguages.contains(language.toLowerCase().trim())) {
-                SlackUtils.sendMessageToSlack(MainActivity.this, "An incorrect or null language value was detected in a "+source
-                        +" campaign’s deferred deep link with the following details: \n"
-                        + deepLinkUri + "\n"
-                        + "User affected:: " + pseudoId + "\n"
-                        + "Detected in data at: " + convertEpochToDate(currentEpochTime) + "\n"
-                        + "Alerted in Slack: " + convertEpochToDate(initialSlackAlertTime));
+                SlackUtils.sendMessageToSlack(MainActivity.this, String.valueOf(message));
                 showLanguagePopup();
                 loadingIndicator.setVisibility(View.GONE);
                 selectedLanguage="";

--- a/app/src/main/java/org/curiouslearning/container/MainActivity.java
+++ b/app/src/main/java/org/curiouslearning/container/MainActivity.java
@@ -96,7 +96,7 @@ public class MainActivity extends BaseActivity {
                     editor.putBoolean(REFERRER_HANDLED_KEY, true);
                     editor.apply();
                     if((language!=null && language.length()>0) || fullURL.contains("curiousreader://app")) {
-                        validLanguage(language, "google", fullURL);
+                        validLanguage(language, "google", fullURL.replace("deferred_deeplink=",""));
                         String pseudoId = prefs.getString("pseudoId", "");
                         String manifestVrsn = prefs.getString("manifestVersion", "");
                         String lang ="";
@@ -260,7 +260,12 @@ public class MainActivity extends BaseActivity {
         long currentEpochTime = AnalyticsUtils.getCurrentEpochTime();
         String pseudoId = prefs.getString("pseudoId", "");
         if( language == null || language.length()==0 ){
-            SlackUtils.sendMessageToSlack(MainActivity.this, "Language is incorrect or null for " + source + " deferred deep link URL: " + deepLinkUri + " , cr_user_id: " + pseudoId + " , currentTimestamp: " + convertEpochToDate(currentEpochTime) + " , initialSlackAlertTime: " + convertEpochToDate(initialSlackAlertTime));
+            SlackUtils.sendMessageToSlack(MainActivity.this, "An incorrect or null language value was detected in a "+source
+                    +" campaign’s deferred deep link with the following details: \n"
+                    + deepLinkUri + "\n"
+                    + "User affected:: " + pseudoId + "\n"
+                    + "Detected in data at: " + convertEpochToDate(currentEpochTime) + "\n"
+                    + "Alerted in Slack: " + convertEpochToDate(initialSlackAlertTime));
             showLanguagePopup();
             return;
         }
@@ -269,7 +274,12 @@ public class MainActivity extends BaseActivity {
                     .map(String::toLowerCase)
                     .collect(Collectors.toList());
             if (lowerCaseLanguages!=null && lowerCaseLanguages.size() > 0 &&!lowerCaseLanguages.contains(language.toLowerCase().trim())) {
-                SlackUtils.sendMessageToSlack(MainActivity.this, "Language is incorrect or null for " + source + " deferred deep link URL: " + deepLinkUri + " , cr_user_id: " + pseudoId + " , currentTimestamp: " + convertEpochToDate(currentEpochTime) + " , initialSlackAlertTime: " + convertEpochToDate(initialSlackAlertTime));
+                SlackUtils.sendMessageToSlack(MainActivity.this, "An incorrect or null language value was detected in a "+source
+                        +" campaign’s deferred deep link with the following details: \n"
+                        + deepLinkUri + "\n"
+                        + "User affected:: " + pseudoId + "\n"
+                        + "Detected in data at: " + convertEpochToDate(currentEpochTime) + "\n"
+                        + "Alerted in Slack: " + convertEpochToDate(initialSlackAlertTime));
                 showLanguagePopup();
                 loadingIndicator.setVisibility(View.GONE);
                 selectedLanguage="";

--- a/app/src/main/java/org/curiouslearning/container/MainActivity.java
+++ b/app/src/main/java/org/curiouslearning/container/MainActivity.java
@@ -259,14 +259,15 @@ public class MainActivity extends BaseActivity {
         String language = deferredLang.trim();
         long currentEpochTime = AnalyticsUtils.getCurrentEpochTime();
         String pseudoId = prefs.getString("pseudoId", "");
-        String[] uriParts = deepLinkUri.split("\"(?<=[?&])\"");
+        String[] uriParts = deepLinkUri.split("(?=[?&])");
         StringBuilder message = new StringBuilder();
         message.append("An incorrect or null language value was detected in a ")
                 .append(source)
-                .append(" campaign’s deferred deep link with the following details:\n");
+                .append(" campaign’s deferred deep link with the following details:\n\n");
         for (String part : uriParts) {
             message.append(part).append("\n");
         }
+        message.append("\n");
         message.append("User affected:: ").append(pseudoId).append("\n")
                 .append("Detected in data at: ").append(convertEpochToDate(currentEpochTime)).append("\n")
                 .append("Alerted in Slack: ").append(convertEpochToDate(initialSlackAlertTime));

--- a/app/src/main/java/org/curiouslearning/container/installreferrer/InstallReferrerManager.java
+++ b/app/src/main/java/org/curiouslearning/container/installreferrer/InstallReferrerManager.java
@@ -91,12 +91,12 @@ public class InstallReferrerManager {
         Uri uri = Uri.parse("http://dummyurl.com/?" +referrerUrl);
         String deeplink= uri.getQueryParameter("deferred_deeplink");
         if(deeplink!=null && deeplink.contains("curiousreader://app?language")){
-            callback.onReferrerReceived(deeplink.replace("curiousreader://app?language=", ""), String.valueOf(uri));
+            callback.onReferrerReceived(deeplink.replace("curiousreader://app?language=", ""), referrerUrl);
         }else if(deeplink !=null){
-            callback.onReferrerReceived("", String.valueOf(uri));
+            callback.onReferrerReceived("", referrerUrl);
         }
         else{
-            callback.onReferrerReceived("", String.valueOf(uri));
+            callback.onReferrerReceived("", referrerUrl);
         }
         String source = uri.getQueryParameter("source");
         String campaign_id = uri.getQueryParameter("campaign_id");


### PR DESCRIPTION
# Changes
- app/src/main/java/org/curiouslearning/container/MainActivity.java
- app/src/main/java/org/curiouslearning/container/installreferrer/InstallReferrerManager.java

# How to test
- When viewing the alert messages in the marketing Slack channel, the messages should no longer contain the "dummyUrl" prefix.

Ref: [CR-295](https://curiouslearning.atlassian.net/jira/software/projects/CR/boards/7?selectedIssue=CR-295)


[CR-295]: https://curiouslearning.atlassian.net/browse/CR-295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ