### PR TITLE
fix: cr-307 deep link fix for unsupported install referrer devices

### DIFF
--- a/app/src/main/java/org/curiouslearning/container/installreferrer/InstallReferrerManager.java
+++ b/app/src/main/java/org/curiouslearning/container/installreferrer/InstallReferrerManager.java
@@ -53,9 +53,11 @@ public class InstallReferrerManager {
                         break;
                     case InstallReferrerClient.InstallReferrerResponse.FEATURE_NOT_SUPPORTED:
                         Log.d("referrer", "install referrer not supported");
+                        callback.onReferrerReceived("", "");
                         break;
                     case InstallReferrerClient.InstallReferrerResponse.SERVICE_UNAVAILABLE:
                         Log.d("referrer", "install referrer service unavailable");
+                        callback.onReferrerReceived("", "");
                         break;
                 }
             }


### PR DESCRIPTION
# Changes
- app/src/main/java/org/curiouslearning/container/installreferrer/InstallReferrerManager.java
# How to test
- Check the playstore and facebook deferred deep link for unsupported install referrer devices(eg.- Redmi note 11 & 12 pro)

Ref: [CR-307](https://curiouslearning.atlassian.net/jira/software/projects/CR/boards/7?selectedIssue=CR-307)


[CR-307]: https://curiouslearning.atlassian.net/browse/CR-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ