### PR TITLE
CR 415 - Added dynamic buildtype

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,10 @@ plugins {
     id 'com.google.firebase.crashlytics'
     id 'jacoco'
 }
+def buildBranch = project.hasProperty("buildBranch") ? project.getProperty("buildBranch") : "main"
+def apiUrl = buildBranch == "main" ?
+        "https://devcuriousreader.wpcomstaging.com/container_app_manifest/prod/" :
+        "https://devcuriousreader.wpcomstaging.com/container_app_manifest/testing_branch/"
 
 android {
     namespace 'org.curiouslearning.container'
@@ -41,15 +45,11 @@ android {
     }
 
     buildTypes {
-        debug{
-            testCoverageEnabled true
-            buildConfigField "String", "API_URL", "\"https://devcuriousreader.wpcomstaging.com/container_app_manifest/dev/\""
-        }
         release {
             signingConfig signingConfigs.release
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            buildConfigField "String", "API_URL", "\"https://devcuriousreader.wpcomstaging.com/container_app_manifest/prod/\""
+            buildConfigField "String", "API_URL", "\"${apiUrl}\""
         }
     }
     compileOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,10 @@ android {
     }
 
     buildTypes {
+        debug{
+            testCoverageEnabled true
+            buildConfigField "String", "API_URL", "\"https://devcuriousreader.wpcomstaging.com/container_app_manifest/testing_branch/\""
+        }
         release {
             signingConfig signingConfigs.release
             minifyEnabled false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,11 @@ def buildBranch = project.hasProperty("buildBranch") ? project.getProperty("buil
 def apiUrl = buildBranch == "main" ?
         "https://devcuriousreader.wpcomstaging.com/container_app_manifest/prod/" :
         "https://devcuriousreader.wpcomstaging.com/container_app_manifest/testing_branch/"
+task printApiUrl {
+    doLast {
+        println(apiUrl)
+    }
+}
 
 android {
     namespace 'org.curiouslearning.container'

--- a/app/fastlane/Fastfile
+++ b/app/fastlane/Fastfile
@@ -6,6 +6,8 @@ platform :android do
   lane :deploy do
     last_commit = sh("git log -1 --pretty=%B").strip
     current_branch = sh("git rev-parse --abbrev-ref HEAD").strip
+    api_url = sh("cd ../ && ./gradlew -q printApiUrl -PbuildBranch=#{current_branch}").strip
+    UI.message("📡 API_URL from build.gradle: #{api_url}")
 
     release_notes = {
       "en-US" => "Bug Fixes!",

--- a/app/fastlane/Fastfile
+++ b/app/fastlane/Fastfile
@@ -32,7 +32,10 @@ platform :android do
       gradle(
         task: "bundle",
         build_type: "Release",
-        project_dir: "../"
+        project_dir: "../",
+        properties: {
+            "buildBranch" => current_branch
+          }
       )
 
       # Use 'beta' for main branch, 'internal' otherwise

--- a/app/src/main/java/org/curiouslearning/container/data/remote/RetrofitInstance.java
+++ b/app/src/main/java/org/curiouslearning/container/data/remote/RetrofitInstance.java
@@ -35,7 +35,6 @@ public class RetrofitInstance {
 
     public static RetrofitInstance getInstance() {
         Log.d("buildtype api Url ",URL);
-        System.out.println("here is url>>> "+URL);
         if (retrofit == null) {
             retrofitInstance = new RetrofitInstance();
             retrofit = new Retrofit.Builder()

--- a/app/src/main/java/org/curiouslearning/container/data/remote/RetrofitInstance.java
+++ b/app/src/main/java/org/curiouslearning/container/data/remote/RetrofitInstance.java
@@ -29,9 +29,11 @@ public class RetrofitInstance {
     private Map<String, Object> data;
 
     private static String URL = BuildConfig.API_URL;;
+
     private List<WebApp> webApps;
 
     public static RetrofitInstance getInstance() {
+        System.out.println("here is url>>> "+URL);
         if (retrofit == null) {
             retrofitInstance = new RetrofitInstance();
             retrofit = new Retrofit.Builder()

--- a/app/src/main/java/org/curiouslearning/container/data/remote/RetrofitInstance.java
+++ b/app/src/main/java/org/curiouslearning/container/data/remote/RetrofitInstance.java
@@ -1,5 +1,7 @@
 package org.curiouslearning.container.data.remote;
 
+import android.util.Log;
+
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -27,12 +29,12 @@ public class RetrofitInstance {
     private static Retrofit retrofit;
     private static RetrofitInstance retrofitInstance;
     private Map<String, Object> data;
-
     private static String URL = BuildConfig.API_URL;;
 
     private List<WebApp> webApps;
 
     public static RetrofitInstance getInstance() {
+        Log.d("buildtype api Url ",URL);
         System.out.println("here is url>>> "+URL);
         if (retrofit == null) {
             retrofitInstance = new RetrofitInstance();


### PR DESCRIPTION
# Changes
- app/build.gradle
- app/fastlane/Fastfile
- app/src/main/java/org/curiouslearning/container/data/remote/RetrofitInstance.java

# How to test
- For production app it should use prod wordpress manifest.

Ref: [CR-415](https://curiouslearning.atlassian.net/jira/software/projects/CR/boards/7?selectedIssue=CR-415)


[CR-415]: https://curiouslearning.atlassian.net/browse/CR-415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ