### PR TITLE
Hotfix for language dialog crash

### DIFF
--- a/app/src/main/java/org/curiouslearning/container/MainActivity.java
+++ b/app/src/main/java/org/curiouslearning/container/MainActivity.java
@@ -438,7 +438,22 @@ public class MainActivity extends BaseActivity {
                 }
 
             });
+            try {
+            if (isFinishing() ||  isDestroyed()) {
+                Log.w(TAG, "showLanguagePopup: Activity is finishing or destroyed, not showing dialog.");
+                return;
+            }
+            dialog.setContentView(R.layout.language_popup);
+            dialog.setCanceledOnTouchOutside(false);
+            dialog.getWindow().setBackgroundDrawable(null);
             dialog.show();
+        } catch (Exception e) {
+                FirebaseCrashlytics.getInstance().log("showLanguagePopup: Failed to show dialog");
+                FirebaseCrashlytics.getInstance().recordException(
+                        new RuntimeException("showLanguagePopup: Failed to show dialog", e)
+                );
+            Log.e(TAG, "showLanguagePopup: Failed to show dialog", e);
+        }
         }
     }
 

--- a/app/src/main/java/org/curiouslearning/container/MainActivity.java
+++ b/app/src/main/java/org/curiouslearning/container/MainActivity.java
@@ -443,9 +443,6 @@ public class MainActivity extends BaseActivity {
                 Log.w(TAG, "showLanguagePopup: Activity is finishing or destroyed, not showing dialog.");
                 return;
             }
-            dialog.setContentView(R.layout.language_popup);
-            dialog.setCanceledOnTouchOutside(false);
-            dialog.getWindow().setBackgroundDrawable(null);
             dialog.show();
         } catch (Exception e) {
                 FirebaseCrashlytics.getInstance().log("showLanguagePopup: Failed to show dialog");


### PR DESCRIPTION
# Changes
- app/src/main/java/org/curiouslearning/container/MainActivity.java

# How to test
- Check the firebase crash analytics report.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when opening the language selection dialog. The app now avoids showing the dialog if the screen is closing or inactive, reducing rare crashes and unexpected behavior.
  * Enhanced error handling around dialog display to ensure a smoother experience if opening the dialog fails, with issues gracefully handled without disrupting usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->