### PR TITLE
Bump app version to 2.34.2 - Release

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "org.curiouslearning.container"
         minSdk 24
         targetSdk 35
-        versionCode 69
-        versionName "2.34.1"
+        versionCode 70
+        versionName "2.34.2"
         
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Increment Android app version for next release: update versionCode from 69 to 70 and versionName to "2.34.2" in app/build.gradle.

# Changes
- version updated to 2.34.2

# How to test
- Check version number

Ref: [MR-45](https://curiouslearning.atlassian.net/jira/software/projects/MR/boards/76?selectedIssue=MR-45)


[MR-45]: https://curiouslearning.atlassian.net/browse/MR-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump: Updated app version to 2.34.2 (build 70).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->