### PR TITLE
fix: [MR-84] added container version to firestore payload

### DIFF
--- a/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
+++ b/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
@@ -8,6 +8,7 @@ import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.Query;
 
+import org.curiouslearning.container.BuildConfig;
 import org.curiouslearning.container.core.subapp.payload.AppEventPayload;
 
 import java.util.HashMap;
@@ -51,6 +52,10 @@ public class DefaultAppEventPayloadHandler
         }
 
         payload.collection = normalizedCollection;
+
+        if (payload.data instanceof Map) {
+            ((Map<String, Object>) payload.data).put("container_version", BuildConfig.VERSION_NAME);
+        }
 
         switch (normalizedCollection) {
 


### PR DESCRIPTION
# Changes
- added container version to firestore payload

# How to test
- Open Assessment inside Container App, then complete the assessment, Firestore should store now Container App Version

Ref: [MR-84](https://curiouslearning.atlassian.net/browse/MR-84)


[MR-84]: https://curiouslearning.atlassian.net/browse/MR-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced event tracking by including container version information in stored event data, improving diagnostic and monitoring capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curiouslearning/CRcontainer/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->