### PR TITLE
feat: [CR] Summary Data Improvements (MR-78)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,7 +27,7 @@ android {
     }
     defaultConfig {
         applicationId "org.curiouslearning.container"
-        minSdk 24
+        minSdk 26
         targetSdk 35
         versionCode 70
         versionName "2.34.2"

--- a/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
+++ b/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
@@ -43,8 +43,8 @@ public class DefaultAppEventPayloadHandler
 
         if (payload.cr_user_id == null || payload.cr_user_id.trim().isEmpty() ||
                 payload.app_id == null || payload.app_id.trim().isEmpty() ||
-                normalizedCollection == null || normalizedCollection.isEmpty() ||
-            ) {
+                normalizedCollection == null || normalizedCollection.isEmpty()
+        ) {
 
             Log.e(TAG, "Invalid payload — missing or blank required fields");
             return;
@@ -144,13 +144,12 @@ public class DefaultAppEventPayloadHandler
                 .whereEqualTo("app_id", payload.app_id)
                 .limit(1);
 
+        Map<String, Object> record = new HashMap<>();
+        record.put("cr_user_id", payload.cr_user_id);
+        record.put("app_id", payload.app_id);
+
         query.get()
                 .addOnSuccessListener(querySnapshot -> {
-
-                    Map<String, Object> record = new HashMap<>();
-                    record.put("cr_user_id", payload.cr_user_id);
-                    record.put("app_id", payload.app_id);
-
                     if (!querySnapshot.isEmpty()) {
 
                         List<DocumentSnapshot> documents = querySnapshot.getDocuments();
@@ -198,9 +197,6 @@ public class DefaultAppEventPayloadHandler
         Map<String, Object> newData =
                 new HashMap<>((Map<String, Object>) payload.data);
 
-        Map<String, Object> record = new HashMap<>();
-        record.put("cr_user_id", payload.cr_user_id);
-        record.put("app_id", payload.app_id);
         record.put("collection", payload.collection);
         record.put("data", newData);
         record.put("created_at", Instant.now().toString());

--- a/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
+++ b/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
@@ -10,6 +10,7 @@ import com.google.firebase.firestore.Query;
 
 import org.curiouslearning.container.core.subapp.payload.AppEventPayload;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -28,8 +29,7 @@ public class DefaultAppEventPayloadHandler
         Log.d(
                 TAG,
                 "Accepted payload | app_id=" + payload.app_id +
-                        " collection=" + payload.collection +
-                        " timestamp=" + payload.timestamp
+                        " collection=" + payload.collection
         );
 
         storePayload(payload);
@@ -44,7 +44,7 @@ public class DefaultAppEventPayloadHandler
         if (payload.cr_user_id == null || payload.cr_user_id.trim().isEmpty() ||
                 payload.app_id == null || payload.app_id.trim().isEmpty() ||
                 normalizedCollection == null || normalizedCollection.isEmpty() ||
-                payload.timestamp == null) {
+            ) {
 
             Log.e(TAG, "Invalid payload — missing or blank required fields");
             return;
@@ -113,7 +113,8 @@ public class DefaultAppEventPayloadHandler
         record.put("cr_user_id", payload.cr_user_id);
         record.put("app_id", payload.app_id);
         record.put("collection", payload.collection);
-        record.put("timestamp", payload.timestamp);
+        record.put("created_at", Instant.now().toString());
+        record.put("schema_version", payload.schema_version != null ? payload.schema_version : "unknown");
 
         Map<String, Object> data =
                 new HashMap<>((Map<String, Object>) payload.data);
@@ -149,8 +150,6 @@ public class DefaultAppEventPayloadHandler
                     Map<String, Object> record = new HashMap<>();
                     record.put("cr_user_id", payload.cr_user_id);
                     record.put("app_id", payload.app_id);
-                    record.put("collection", payload.collection);
-                    record.put("timestamp", payload.timestamp);
 
                     if (!querySnapshot.isEmpty()) {
 
@@ -161,7 +160,8 @@ public class DefaultAppEventPayloadHandler
                                 mergeData(existingDoc, payload);
 
                         record.put("data", mergedData);
-
+                        record.put("updated_at", Instant.now().toString());
+                        
                         db.collection(payload.collection)
                                 .document(existingDoc.getId())
                                 .set(record)
@@ -179,13 +179,6 @@ public class DefaultAppEventPayloadHandler
                 .addOnFailureListener(e -> {
 
                     Log.w(TAG, "Query failed — creating new summary record", e);
-
-                    Map<String, Object> record = new HashMap<>();
-                    record.put("cr_user_id", payload.cr_user_id);
-                    record.put("app_id", payload.app_id);
-                    record.put("collection", payload.collection);
-                    record.put("timestamp", payload.timestamp);
-
                     createNewSummaryDoc(db, payload, record);
                 });
     }
@@ -205,8 +198,14 @@ public class DefaultAppEventPayloadHandler
         Map<String, Object> newData =
                 new HashMap<>((Map<String, Object>) payload.data);
 
+        Map<String, Object> record = new HashMap<>();
+        record.put("cr_user_id", payload.cr_user_id);
+        record.put("app_id", payload.app_id);
+        record.put("collection", payload.collection);
         record.put("data", newData);
-
+        record.put("created_at", Instant.now().toString());
+        record.put("schema_version", payload.schema_version != null ? payload.schema_version : "unknown");
+        
         db.collection(payload.collection)
                 .add(record)
                 .addOnSuccessListener(ref ->

--- a/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
+++ b/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
@@ -87,6 +87,10 @@ public class DefaultAppEventPayloadHandler
             return COLLECTION_USER_SESSION;
         }
 
+        if ("summary_data".equals(normalized)) {
+            return COLLECTION_SUMMARY;
+        }
+
         return normalized;
     }
 
@@ -162,7 +166,7 @@ public class DefaultAppEventPayloadHandler
                                 .document(existingDoc.getId())
                                 .set(record)
                                 .addOnSuccessListener(aVoid ->
-                                        Log.d(TAG, "Updated summary payload"))
+                                        Log.d(TAG, "Updated summary payload with id: "+existingDoc.getId()))
                                 .addOnFailureListener(e ->
                                         Log.e(TAG, "Failed to update summary payload", e));
 

--- a/app/src/main/java/org/curiouslearning/container/core/subapp/payload/AppEventPayload.java
+++ b/app/src/main/java/org/curiouslearning/container/core/subapp/payload/AppEventPayload.java
@@ -10,4 +10,5 @@ public class AppEventPayload {
     public Object data;
     public Map<String, String> options;
     public String timestamp;
+    public String schema_version;
 }


### PR DESCRIPTION
# Changes
- removed old timestamp
- added created_at
- added updated_at
- added schema_version
- minor refactor

Ref: [MR-78](https://curiouslearning.atlassian.net/browse/MR-78)


[MR-78]: https://curiouslearning.atlassian.net/browse/MR-78?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved payload validation and normalization for more consistent handling of summary and session data
  * Revised how session and summary records are created and updated to reliably include metadata (timestamps and schema info)

* **Chore**
  * Increased Android minimum SDK level for the app

* **New Fields**
  * Added a payload schema_version field to carry schema version information

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curiouslearning/CRcontainer/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->