### PR TITLE
feat: add study user id to app launch analytics

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "org.curiouslearning.container"
         minSdk 24
         targetSdk 35
-        versionCode 70
-        versionName "2.34.2"
+        versionCode 73
+        versionName "2.34.3"
         
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/org/curiouslearning/container/MainActivity.java
+++ b/app/src/main/java/org/curiouslearning/container/MainActivity.java
@@ -408,6 +408,7 @@ public class MainActivity extends BaseActivity {
                     // Replace auto-generated cr_user_id with the confirmed one
                     SharedPreferences.Editor editor = prefs.edit();
                     editor.putString("pseudoId", newId);
+                    editor.putString(AnalyticsUtils.STUDY_USER_ID, newId);
                     if (studyConsent != null && !studyConsent.isEmpty()) {
                         editor.putString("studyConsent", studyConsent);
                     }

--- a/app/src/main/java/org/curiouslearning/container/firebase/AnalyticsUtils.java
+++ b/app/src/main/java/org/curiouslearning/container/firebase/AnalyticsUtils.java
@@ -20,6 +20,8 @@ public class AnalyticsUtils {
 
     private static FirebaseAnalytics mFirebaseAnalytics;
     private static final String PREFS_NAME = "InstallReferrerPrefs";
+    public static final String APP_CACHED_PREFS = "appCached";
+    public static final String STUDY_USER_ID = "study_user_id";
     private static final String SOURCE = "source";
     private static final String CAMPAIGN_ID = "campaign_id";
 
@@ -39,6 +41,18 @@ public class AnalyticsUtils {
         bundle.putString("raw_referrer_url", rawReferrerUrl.isEmpty() ? null : rawReferrerUrl);
     }
 
+    private static void addStudyUserIdForAppLaunch(Context context, String eventName, Bundle bundle) {
+        if (!"app_launch".equals(eventName)) {
+            return;
+        }
+
+        SharedPreferences appPrefs = context.getSharedPreferences(APP_CACHED_PREFS, Context.MODE_PRIVATE);
+        String studyUserId = appPrefs.getString(STUDY_USER_ID, "");
+        if (studyUserId != null && !studyUserId.isEmpty()) {
+            bundle.putString(STUDY_USER_ID, studyUserId);
+        }
+    }
+
     public static void logEvent(Context context, String eventName, String appName, String appUrl, String pseudoId,
             String language) {
         FirebaseAnalytics firebaseAnalytics = getFirebaseAnalytics(context);
@@ -53,6 +67,7 @@ public class AnalyticsUtils {
 
         // Add the raw_referrer_url from install_referrer_prefs as well (only if not empty)
         addRawReferrerUrl(context, bundle);
+        addStudyUserIdForAppLaunch(context, eventName, bundle);
 
         firebaseAnalytics.setUserProperty("source", source);
         firebaseAnalytics.setUserProperty("campaign_id", campaign_id);

--- a/app/src/test/java/org/curiouslearning/container/AnalyticsUtilsCustomEventsTest.java
+++ b/app/src/test/java/org/curiouslearning/container/AnalyticsUtilsCustomEventsTest.java
@@ -2,6 +2,7 @@
 package org.curiouslearning.container;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
@@ -31,6 +32,7 @@ public class AnalyticsUtilsCustomEventsTest {
 
     private Context context;
     private SharedPreferences prefs;
+    private SharedPreferences appPrefs;
 
     @Before
     public void setup() throws Exception {
@@ -43,6 +45,8 @@ public class AnalyticsUtilsCustomEventsTest {
                 .putString("source", "test_source")
                 .putString("campaign_id", "test_campaign")
                 .apply();
+        appPrefs = context.getSharedPreferences(AnalyticsUtils.APP_CACHED_PREFS, Context.MODE_PRIVATE);
+        appPrefs.edit().clear().apply();
 
         // **Reset the cached FirebaseAnalytics** so our static mock takes effect
         Field mFaField = AnalyticsUtils.class.getDeclaredField("mFirebaseAnalytics");
@@ -52,6 +56,8 @@ public class AnalyticsUtilsCustomEventsTest {
 
     @Test
     public void testLogEvent_appLaunch() {
+        appPrefs.edit().putString(AnalyticsUtils.STUDY_USER_ID, "12345").apply();
+
         // Prepare a spy for FirebaseAnalytics
         FirebaseAnalytics spyFA = Mockito.spy(FirebaseAnalytics.getInstance(context));
 
@@ -77,10 +83,34 @@ public class AnalyticsUtilsCustomEventsTest {
             assertEquals("https://example.com/ftm", b.getString("web_app_url"));
             assertEquals("user123", b.getString("cr_user_id"));
             assertEquals("Hindi", b.getString("cr_language"));
+            assertEquals("12345", b.getString("study_user_id"));
 
             // Verify user properties on the same instance
             verify(spyFA).setUserProperty("source", "test_source");
             verify(spyFA).setUserProperty("campaign_id", "test_campaign");
+        }
+    }
+
+    @Test
+    public void testLogEvent_appLaunchWithoutStudyUserId() {
+        FirebaseAnalytics spyFA = Mockito.spy(FirebaseAnalytics.getInstance(context));
+
+        try (MockedStatic<FirebaseAnalytics> faStatic = Mockito.mockStatic(FirebaseAnalytics.class)) {
+            faStatic.when(() -> FirebaseAnalytics.getInstance(context)).thenReturn(spyFA);
+
+            AnalyticsUtils.logEvent(
+                    context,
+                    "app_launch",
+                    "Feed the Monster",
+                    "https://example.com/ftm",
+                    "user123",
+                    "Hindi"
+            );
+
+            ArgumentCaptor<Bundle> captor = ArgumentCaptor.forClass(Bundle.class);
+            verify(spyFA).logEvent(eq("app_launch"), captor.capture());
+            Bundle b = captor.getValue();
+            assertFalse(b.containsKey("study_user_id"));
         }
     }
 
@@ -100,6 +130,15 @@ public class AnalyticsUtilsCustomEventsTest {
 //                    "v1.2.3",
 //                    "false"
 //            );
+            AnalyticsUtils.logLanguageSelectEvent(
+                    context,
+                    "language_selected",
+                    "user456",
+                    "Nepali",
+                    "v1.2.3",
+                    "false",
+                    ""
+            );
 
             // Capture and assert that logEvent was called
             ArgumentCaptor<Bundle> captor = ArgumentCaptor.forClass(Bundle.class);


### PR DESCRIPTION
# Changes
- Persist confirmed study_user_id after successful study enrollment
- Store the study ID alongside the existing pseudoId using a dedicated preference key
- Append study_user_id only to app_launch Firebase event parameters when available
- Leave unenrolled app_launch events unchanged by omitting study_user_id
- Add unit coverage for app_launch events with and without a persisted study_user_id
- Restore the existing language_selected analytics test invocation so the test class passes

# How to test
- Using the unit tests that exist in the project and by sending the app_launch events and then checking them through BigQuery if being part of the study by accepting the study modal

Ref: [AJ-657](https://curiouslearning.atlassian.net/browse/AJ-657)


[AJ-657]: https://curiouslearning.atlassian.net/browse/AJ-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Version Update**
  * Released version 2.34.3

* **Improvements**
  * Enhanced analytics to include study user identification for improved data tracking

* **Tests**
  * Updated analytics tests to verify study user tracking behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curiouslearning/CRcontainer/pull/257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->