### PR TITLE
feat: replace toast with custom success dialog

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "org.curiouslearning.container"
         minSdk 24
         targetSdk 35
-        versionCode 70
-        versionName "2.34.2"
+        versionCode 73
+        versionName "2.34.3"
         
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/org/curiouslearning/container/MainActivity.java
+++ b/app/src/main/java/org/curiouslearning/container/MainActivity.java
@@ -408,6 +408,7 @@ public class MainActivity extends BaseActivity {
                     // Replace auto-generated cr_user_id with the confirmed one
                     SharedPreferences.Editor editor = prefs.edit();
                     editor.putString("pseudoId", newId);
+                    editor.putString(AnalyticsUtils.STUDY_USER_ID, newId);
                     if (studyConsent != null && !studyConsent.isEmpty()) {
                         editor.putString("studyConsent", studyConsent);
                     }

--- a/app/src/main/java/org/curiouslearning/container/MainActivity.java
+++ b/app/src/main/java/org/curiouslearning/container/MainActivity.java
@@ -431,13 +431,16 @@ public class MainActivity extends BaseActivity {
                         loadApps(selectedLanguage);
                     }
                     
-                    android.widget.Toast.makeText(MainActivity.this, "🎉🎉🎉", android.widget.Toast.LENGTH_LONG).show();
+                    Runnable onDismiss = () -> {
+                        if (selectedLanguage == null || selectedLanguage.isEmpty()) {
+                            showLanguagePopup();
+                        }
+                    };
+                    
+                    showSuccessDialog(onDismiss);
                     
                     confirmDialog.dismiss();
                     isHandlingIdConfirmation = false;
-                    if (selectedLanguage == null || selectedLanguage.isEmpty()) {
-                        showLanguagePopup();
-                    }
                 });
 
                 confirmDialog.show();
@@ -460,6 +463,44 @@ public class MainActivity extends BaseActivity {
             } catch (Exception e) {
                 Log.e(TAG, "showConfirmIdDialog: Failed to show confirmation dialog", e);
                 isHandlingIdConfirmation = false;
+            }
+        });
+    }
+
+    private void showSuccessDialog(Runnable onDismissAction) {
+        runOnUiThread(() -> {
+            try {
+                final Dialog successDialog = new Dialog(this);
+                successDialog.setContentView(R.layout.dialog_enrollment_success);
+                successDialog.setCanceledOnTouchOutside(true);
+                successDialog.setOnDismissListener(dialog -> {
+                    if (onDismissAction != null) {
+                        onDismissAction.run();
+                    }
+                });
+                if (successDialog.getWindow() != null) {
+                    successDialog.getWindow().setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(android.graphics.Color.TRANSPARENT));
+                }
+
+                View container = successDialog.findViewById(R.id.success_container);
+                if (container != null) {
+                    container.setOnClickListener(v -> {
+                        if (successDialog.isShowing()) {
+                            successDialog.dismiss();
+                        }
+                    });
+                }
+
+                successDialog.show();
+
+                new Handler(Looper.getMainLooper()).postDelayed(() -> {
+                    if (successDialog.isShowing()) {
+                        successDialog.dismiss();
+                    }
+                }, 2000);
+
+            } catch (Exception e) {
+                Log.e(TAG, "showSuccessDialog: Failed to show success dialog", e);
             }
         });
     }

--- a/app/src/main/java/org/curiouslearning/container/firebase/AnalyticsUtils.java
+++ b/app/src/main/java/org/curiouslearning/container/firebase/AnalyticsUtils.java
@@ -20,6 +20,8 @@ public class AnalyticsUtils {
 
     private static FirebaseAnalytics mFirebaseAnalytics;
     private static final String PREFS_NAME = "InstallReferrerPrefs";
+    public static final String APP_CACHED_PREFS = "appCached";
+    public static final String STUDY_USER_ID = "study_user_id";
     private static final String SOURCE = "source";
     private static final String CAMPAIGN_ID = "campaign_id";
 
@@ -39,6 +41,18 @@ public class AnalyticsUtils {
         bundle.putString("raw_referrer_url", rawReferrerUrl.isEmpty() ? null : rawReferrerUrl);
     }
 
+    private static void addStudyUserIdForAppLaunch(Context context, String eventName, Bundle bundle) {
+        if (!"app_launch".equals(eventName)) {
+            return;
+        }
+
+        SharedPreferences appPrefs = context.getSharedPreferences(APP_CACHED_PREFS, Context.MODE_PRIVATE);
+        String studyUserId = appPrefs.getString(STUDY_USER_ID, "");
+        if (studyUserId != null && !studyUserId.isEmpty()) {
+            bundle.putString(STUDY_USER_ID, studyUserId);
+        }
+    }
+
     public static void logEvent(Context context, String eventName, String appName, String appUrl, String pseudoId,
             String language) {
         FirebaseAnalytics firebaseAnalytics = getFirebaseAnalytics(context);
@@ -53,6 +67,7 @@ public class AnalyticsUtils {
 
         // Add the raw_referrer_url from install_referrer_prefs as well (only if not empty)
         addRawReferrerUrl(context, bundle);
+        addStudyUserIdForAppLaunch(context, eventName, bundle);
 
         firebaseAnalytics.setUserProperty("source", source);
         firebaseAnalytics.setUserProperty("campaign_id", campaign_id);

--- a/app/src/main/res/layout/dialog_enrollment_success.xml
+++ b/app/src/main/res/layout/dialog_enrollment_success.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/success_container"
+        android:layout_width="320dp"
+        android:layout_height="240dp"
+        android:layout_gravity="center"
+        android:layout_margin="24dp"
+        android:background="@drawable/bg_dialog"
+        android:clickable="true"
+        android:focusable="true">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="🎉"
+            android:textSize="80sp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</FrameLayout>

--- a/app/src/test/java/org/curiouslearning/container/AnalyticsUtilsCustomEventsTest.java
+++ b/app/src/test/java/org/curiouslearning/container/AnalyticsUtilsCustomEventsTest.java
@@ -2,6 +2,7 @@
 package org.curiouslearning.container;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 
@@ -31,6 +32,7 @@ public class AnalyticsUtilsCustomEventsTest {
 
     private Context context;
     private SharedPreferences prefs;
+    private SharedPreferences appPrefs;
 
     @Before
     public void setup() throws Exception {
@@ -43,6 +45,8 @@ public class AnalyticsUtilsCustomEventsTest {
                 .putString("source", "test_source")
                 .putString("campaign_id", "test_campaign")
                 .apply();
+        appPrefs = context.getSharedPreferences(AnalyticsUtils.APP_CACHED_PREFS, Context.MODE_PRIVATE);
+        appPrefs.edit().clear().apply();
 
         // **Reset the cached FirebaseAnalytics** so our static mock takes effect
         Field mFaField = AnalyticsUtils.class.getDeclaredField("mFirebaseAnalytics");
@@ -52,6 +56,8 @@ public class AnalyticsUtilsCustomEventsTest {
 
     @Test
     public void testLogEvent_appLaunch() {
+        appPrefs.edit().putString(AnalyticsUtils.STUDY_USER_ID, "12345").apply();
+
         // Prepare a spy for FirebaseAnalytics
         FirebaseAnalytics spyFA = Mockito.spy(FirebaseAnalytics.getInstance(context));
 
@@ -77,10 +83,34 @@ public class AnalyticsUtilsCustomEventsTest {
             assertEquals("https://example.com/ftm", b.getString("web_app_url"));
             assertEquals("user123", b.getString("cr_user_id"));
             assertEquals("Hindi", b.getString("cr_language"));
+            assertEquals("12345", b.getString("study_user_id"));
 
             // Verify user properties on the same instance
             verify(spyFA).setUserProperty("source", "test_source");
             verify(spyFA).setUserProperty("campaign_id", "test_campaign");
+        }
+    }
+
+    @Test
+    public void testLogEvent_appLaunchWithoutStudyUserId() {
+        FirebaseAnalytics spyFA = Mockito.spy(FirebaseAnalytics.getInstance(context));
+
+        try (MockedStatic<FirebaseAnalytics> faStatic = Mockito.mockStatic(FirebaseAnalytics.class)) {
+            faStatic.when(() -> FirebaseAnalytics.getInstance(context)).thenReturn(spyFA);
+
+            AnalyticsUtils.logEvent(
+                    context,
+                    "app_launch",
+                    "Feed the Monster",
+                    "https://example.com/ftm",
+                    "user123",
+                    "Hindi"
+            );
+
+            ArgumentCaptor<Bundle> captor = ArgumentCaptor.forClass(Bundle.class);
+            verify(spyFA).logEvent(eq("app_launch"), captor.capture());
+            Bundle b = captor.getValue();
+            assertFalse(b.containsKey("study_user_id"));
         }
     }
 
@@ -100,6 +130,15 @@ public class AnalyticsUtilsCustomEventsTest {
 //                    "v1.2.3",
 //                    "false"
 //            );
+            AnalyticsUtils.logLanguageSelectEvent(
+                    context,
+                    "language_selected",
+                    "user456",
+                    "Nepali",
+                    "v1.2.3",
+                    "false",
+                    ""
+            );
 
             // Capture and assert that logEvent was called
             ArgumentCaptor<Bundle> captor = ArgumentCaptor.forClass(Bundle.class);


### PR DESCRIPTION
# Changes
-  replace toast with custom success dialog

Ref: [AJ-658](https://curiouslearning.atlassian.net/browse/AJ-658)


[AJ-658]: https://curiouslearning.atlassian.net/browse/AJ-658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added success dialog that displays after ID enrollment and auto-dismisses after approximately 2 seconds
  * Language selection flow now triggers after enrollment completion if no language preference is set

* **Chores**
  * Updated app version to 2.34.3

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curiouslearning/CRcontainer/pull/258?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->