### PR TITLE
feat: joined study additions

### DIFF
--- a/app/src/main/java/org/curiouslearning/container/MainActivity.java
+++ b/app/src/main/java/org/curiouslearning/container/MainActivity.java
@@ -414,14 +414,19 @@ public class MainActivity extends BaseActivity {
                     }
                     editor.apply();
                     
-                    // Log confirmation event for analytics
-                    AnalyticsUtils.logEvent(
+                    String joinedStudyAppVersion = appVersion;
+                    if (joinedStudyAppVersion == null || joinedStudyAppVersion.isEmpty()) {
+                        joinedStudyAppVersion = AppUtils.getAppVersionName(MainActivity.this);
+                    }
+
+                    // Log joined-study confirmation event for analytics
+                    AnalyticsUtils.logJoinedStudyEvent(
                         MainActivity.this,
-                        "cr_user_id_confirmed",
-                        "Container",
-                        "",
                         newId,
-                        selectedLanguage
+                        selectedLanguage,
+                        joinedStudyAppVersion,
+                        newId,
+                        studyConsent
                     );
 
                     updateDebugOverlay();

--- a/app/src/main/java/org/curiouslearning/container/firebase/AnalyticsUtils.java
+++ b/app/src/main/java/org/curiouslearning/container/firebase/AnalyticsUtils.java
@@ -108,6 +108,33 @@ public class AnalyticsUtils {
         firebaseAnalytics.logEvent(eventName, bundle);
     }
 
+    public static void logJoinedStudyEvent(Context context, String crUserId, String language,
+            String appVersion, String studyUserId, String studyConsent) {
+        FirebaseAnalytics firebaseAnalytics = getFirebaseAnalytics(context);
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        String source = prefs.getString(SOURCE, "");
+        String campaignId = prefs.getString(CAMPAIGN_ID, "");
+        String sanitizedCrUserId = sanitizeStudyUserId(crUserId);
+        String sanitizedStudyUserId = sanitizeStudyUserId(studyUserId);
+
+        Bundle bundle = new Bundle();
+        bundle.putString("cr_language", language);
+        bundle.putString("app_info.version", appVersion);
+        bundle.putString("cr_user_id", sanitizedCrUserId);
+        bundle.putString("source", source);
+        bundle.putString("campaign_id", campaignId);
+        bundle.putString(STUDY_USER_ID, sanitizedStudyUserId);
+        bundle.putString("study_consent", studyConsent);
+
+        firebaseAnalytics.setUserProperty("source", source);
+        firebaseAnalytics.setUserProperty("campaign_id", campaignId);
+        firebaseAnalytics.logEvent("joined_study", bundle);
+    }
+
+    private static String sanitizeStudyUserId(String studyUserId) {
+        return studyUserId == null ? "" : studyUserId.replaceAll("[^0-9]", "");
+    }
+
     public static void logLanguageSelectEvent(Context context, String eventName, String pseudoId, String language,
             String manifestVersion, String autoSelected, String deepLinkUri) {
         FirebaseAnalytics firebaseAnalytics = getFirebaseAnalytics(context);

--- a/app/src/test/java/org/curiouslearning/container/AnalyticsUtilsCustomEventsTest.java
+++ b/app/src/test/java/org/curiouslearning/container/AnalyticsUtilsCustomEventsTest.java
@@ -154,4 +154,57 @@ public class AnalyticsUtilsCustomEventsTest {
             verify(spyFA).setUserProperty("campaign_id", "test_campaign");
         }
     }
+
+    @Test
+    public void testLogJoinedStudyEvent() {
+        FirebaseAnalytics spyFA = Mockito.spy(FirebaseAnalytics.getInstance(context));
+        try (MockedStatic<FirebaseAnalytics> faStatic = Mockito.mockStatic(FirebaseAnalytics.class)) {
+            faStatic.when(() -> FirebaseAnalytics.getInstance(context)).thenReturn(spyFA);
+
+            AnalyticsUtils.logJoinedStudyEvent(
+                    context,
+                    "12345",
+                    "Nepali",
+                    "2.34.3",
+                    "12345",
+                    "true"
+            );
+
+            ArgumentCaptor<Bundle> captor = ArgumentCaptor.forClass(Bundle.class);
+            verify(spyFA).logEvent(eq("joined_study"), captor.capture());
+            Bundle b = captor.getValue();
+            assertEquals("Nepali", b.getString("cr_language"));
+            assertEquals("2.34.3", b.getString("app_info.version"));
+            assertEquals("12345", b.getString("cr_user_id"));
+            assertEquals("test_source", b.getString("source"));
+            assertEquals("test_campaign", b.getString("campaign_id"));
+            assertEquals("12345", b.getString("study_user_id"));
+            assertEquals("true", b.getString("study_consent"));
+            verify(spyFA).setUserProperty("source", "test_source");
+            verify(spyFA).setUserProperty("campaign_id", "test_campaign");
+        }
+    }
+
+    @Test
+    public void testLogJoinedStudyEvent_sanitizesStudyIds() {
+        FirebaseAnalytics spyFA = Mockito.spy(FirebaseAnalytics.getInstance(context));
+        try (MockedStatic<FirebaseAnalytics> faStatic = Mockito.mockStatic(FirebaseAnalytics.class)) {
+            faStatic.when(() -> FirebaseAnalytics.getInstance(context)).thenReturn(spyFA);
+
+            AnalyticsUtils.logJoinedStudyEvent(
+                    context,
+                    "abc-123-xyz",
+                    "Hindi",
+                    "2.34.3",
+                    "study:45 6!",
+                    "true"
+            );
+
+            ArgumentCaptor<Bundle> captor = ArgumentCaptor.forClass(Bundle.class);
+            verify(spyFA).logEvent(eq("joined_study"), captor.capture());
+            Bundle b = captor.getValue();
+            assertEquals("123", b.getString("cr_user_id"));
+            assertEquals("456", b.getString("study_user_id"));
+        }
+    }
 }


### PR DESCRIPTION
# Changes
 - Added AnalyticsUtils.logJoinedStudyEvent(...).
- Replaced the old cr_user_id_confirmed analytics call in MainActivity with joined_study.
- Included all required event parameters:
    cr_language, app_info.version, cr_user_id, source, campaign_id, study_user_id, study_consent.
- Read source and campaign_id from the same InstallReferrerPrefs storage previously used for analytics user
    properties.
- Sanitized cr_user_id and study_user_id so only numeric characters are submitted.
- Used the confirmed study ID as both cr_user_id and study_user_id.
- Used the existing study_consent query parameter as study_consent.
- Used the app version from MainActivity, falling back to AppUtils.getAppVersionName(...) if needed.
- Updated docs/joined_study_plan.md to reflect that cr_user_id_confirmed is replaced on this enrollment path.
- Added unit test coverage in AnalyticsUtilsCustomEventsTest for:
    successful joined_study payload,
    numeric-only ID sanitization,
    inclusion of cached attribution values.

# How to test
- Through the local build or the internal testing version

Ref: [AJ-656](https://curiouslearning.atlassian.net/browse/AJ-656)


[AJ-656]: https://curiouslearning.atlassian.net/browse/AJ-656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved study enrollment analytics tracking to reliably capture app version, language, and consent data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/curiouslearning/CRcontainer/pull/259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->