### PR TITLE
feat: added timestamp fields (MR-78)

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,6 +4,7 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleHome" value="$PROJECT_DIR$/../../../../Program Files/Android/gradle-7.6" />
         <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
@@ -13,7 +14,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,6 +73,9 @@ android {
         }
     }
     compileOptions {
+        // remove when we move to SDK 26 or higher
+        coreLibraryDesugaringEnabled true
+
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -84,6 +87,9 @@ android {
 }
 
 dependencies {
+
+    // remove when we move to SDK 26 or higher
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'
 
     //retrofit
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,7 +27,7 @@ android {
     }
     defaultConfig {
         applicationId "org.curiouslearning.container"
-        minSdk 26
+        minSdk 24
         targetSdk 35
         versionCode 70
         versionName "2.34.2"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,7 +27,7 @@ android {
     }
     defaultConfig {
         applicationId "org.curiouslearning.container"
-        minSdk 24
+        minSdk 26
         targetSdk 35
         versionCode 70
         versionName "2.34.2"

--- a/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
+++ b/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
@@ -43,8 +43,8 @@ public class DefaultAppEventPayloadHandler
 
         if (payload.cr_user_id == null || payload.cr_user_id.trim().isEmpty() ||
                 payload.app_id == null || payload.app_id.trim().isEmpty() ||
-                normalizedCollection == null || normalizedCollection.isEmpty() ||
-            ) {
+                normalizedCollection == null || normalizedCollection.isEmpty()
+        ) {
 
             Log.e(TAG, "Invalid payload — missing or blank required fields");
             return;
@@ -144,13 +144,12 @@ public class DefaultAppEventPayloadHandler
                 .whereEqualTo("app_id", payload.app_id)
                 .limit(1);
 
+        Map<String, Object> record = new HashMap<>();
+        record.put("cr_user_id", payload.cr_user_id);
+        record.put("app_id", payload.app_id);
+
         query.get()
                 .addOnSuccessListener(querySnapshot -> {
-
-                    Map<String, Object> record = new HashMap<>();
-                    record.put("cr_user_id", payload.cr_user_id);
-                    record.put("app_id", payload.app_id);
-
                     if (!querySnapshot.isEmpty()) {
 
                         List<DocumentSnapshot> documents = querySnapshot.getDocuments();
@@ -198,9 +197,6 @@ public class DefaultAppEventPayloadHandler
         Map<String, Object> newData =
                 new HashMap<>((Map<String, Object>) payload.data);
 
-        Map<String, Object> record = new HashMap<>();
-        record.put("cr_user_id", payload.cr_user_id);
-        record.put("app_id", payload.app_id);
         record.put("collection", payload.collection);
         record.put("data", newData);
         record.put("created_at", Instant.now().toString());

--- a/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
+++ b/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 
 import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.SetOptions;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.Query;
 
@@ -158,14 +159,12 @@ public class DefaultAppEventPayloadHandler
                         Map<String, Object> mergedData =
                                 mergeData(existingDoc, payload);
 
-                        record.put("created_at", existingDoc.get("created_at"));
-                        record.put("schema_version", existingDoc.get("schema_version"));
                         record.put("data", mergedData);
                         record.put("updated_at", Instant.now().toString());
                         
                         db.collection(payload.collection)
                                 .document(existingDoc.getId())
-                                .set(record)
+                                .set(record, SetOptions.merge())
                                 .addOnSuccessListener(aVoid ->
                                         Log.d(TAG, "Updated summary payload with id: "+existingDoc.getId()))
                                 .addOnFailureListener(e ->

--- a/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
+++ b/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
@@ -10,6 +10,7 @@ import com.google.firebase.firestore.Query;
 
 import org.curiouslearning.container.core.subapp.payload.AppEventPayload;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -28,8 +29,7 @@ public class DefaultAppEventPayloadHandler
         Log.d(
                 TAG,
                 "Accepted payload | app_id=" + payload.app_id +
-                        " collection=" + payload.collection +
-                        " timestamp=" + payload.timestamp
+                        " collection=" + payload.collection
         );
 
         storePayload(payload);
@@ -44,7 +44,7 @@ public class DefaultAppEventPayloadHandler
         if (payload.cr_user_id == null || payload.cr_user_id.trim().isEmpty() ||
                 payload.app_id == null || payload.app_id.trim().isEmpty() ||
                 normalizedCollection == null || normalizedCollection.isEmpty() ||
-                payload.timestamp == null) {
+            ) {
 
             Log.e(TAG, "Invalid payload — missing or blank required fields");
             return;
@@ -113,7 +113,8 @@ public class DefaultAppEventPayloadHandler
         record.put("cr_user_id", payload.cr_user_id);
         record.put("app_id", payload.app_id);
         record.put("collection", payload.collection);
-        record.put("timestamp", payload.timestamp);
+        record.put("created_at", Instant.now().toString());
+        record.put("schema_version", payload.schema_version != null ? payload.schema_version : "unknown");
 
         Map<String, Object> data =
                 new HashMap<>((Map<String, Object>) payload.data);
@@ -149,8 +150,6 @@ public class DefaultAppEventPayloadHandler
                     Map<String, Object> record = new HashMap<>();
                     record.put("cr_user_id", payload.cr_user_id);
                     record.put("app_id", payload.app_id);
-                    record.put("collection", payload.collection);
-                    record.put("timestamp", payload.timestamp);
 
                     if (!querySnapshot.isEmpty()) {
 
@@ -161,7 +160,8 @@ public class DefaultAppEventPayloadHandler
                                 mergeData(existingDoc, payload);
 
                         record.put("data", mergedData);
-
+                        record.put("updated_at", Instant.now().toString());
+                        
                         db.collection(payload.collection)
                                 .document(existingDoc.getId())
                                 .set(record)
@@ -179,13 +179,6 @@ public class DefaultAppEventPayloadHandler
                 .addOnFailureListener(e -> {
 
                     Log.w(TAG, "Query failed — creating new summary record", e);
-
-                    Map<String, Object> record = new HashMap<>();
-                    record.put("cr_user_id", payload.cr_user_id);
-                    record.put("app_id", payload.app_id);
-                    record.put("collection", payload.collection);
-                    record.put("timestamp", payload.timestamp);
-
                     createNewSummaryDoc(db, payload, record);
                 });
     }
@@ -205,8 +198,14 @@ public class DefaultAppEventPayloadHandler
         Map<String, Object> newData =
                 new HashMap<>((Map<String, Object>) payload.data);
 
+        Map<String, Object> record = new HashMap<>();
+        record.put("cr_user_id", payload.cr_user_id);
+        record.put("app_id", payload.app_id);
+        record.put("collection", payload.collection);
         record.put("data", newData);
-
+        record.put("created_at", Instant.now().toString());
+        record.put("schema_version", payload.schema_version != null ? payload.schema_version : "unknown");
+        
         db.collection(payload.collection)
                 .add(record)
                 .addOnSuccessListener(ref ->

--- a/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
+++ b/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
@@ -158,6 +158,8 @@ public class DefaultAppEventPayloadHandler
                         Map<String, Object> mergedData =
                                 mergeData(existingDoc, payload);
 
+                        record.put("created_at", existingDoc.get("created_at"));
+                        record.put("schema_version", existingDoc.get("schema_version"));
                         record.put("data", mergedData);
                         record.put("updated_at", Instant.now().toString());
                         

--- a/app/src/main/java/org/curiouslearning/container/core/subapp/payload/AppEventPayload.java
+++ b/app/src/main/java/org/curiouslearning/container/core/subapp/payload/AppEventPayload.java
@@ -10,4 +10,5 @@ public class AppEventPayload {
     public Object data;
     public Map<String, String> options;
     public String timestamp;
+    public String schema_version;
 }


### PR DESCRIPTION
# Changes
- added created_at for newly created documents
- added updated_at for updated documents
- fix: reverted version changes
- fix: added sugar coat for backwards compatibility of used class for iso date generation

# How to test
- run emulator
- select poc language
- open ftm dev
- finish any level
- observe created_at, updated_at properties in summary_data

Ref: [MR-78](https://curiouslearning.atlassian.net/browse/MR-78)


[MR-78]: https://curiouslearning.atlassian.net/browse/MR-78?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled Java core library desugaring for broader runtime compatibility.
  * Updated IDE project configuration.

* **Enhancements**
  * Added a schema version field to event payloads.
  * Adjusted event/session record handling: timestamps are now stored as created_at/updated_at, and payload validation now requires a non-empty collection identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->