### PR TITLE
fix: [MR-83] append container_app_version to sub-app WebView URLs

### DIFF
--- a/app/src/main/java/org/curiouslearning/container/WebApp.java
+++ b/app/src/main/java/org/curiouslearning/container/WebApp.java
@@ -152,6 +152,7 @@ public class WebApp extends BaseActivity {
                 Log.w("WebApp", "Missing campaign_id parameter for app: " + appUrl);
             }
         }
+        appUrl = addContainerAppVersionToUrl(appUrl);
         if (appUrl.contains("docs.google.com/forms")) {
             webView.loadUrl(addCrUserIdToFormUrl(appUrl));
         } else if (appUrl.contains("welcome_parent_video")) {
@@ -202,6 +203,12 @@ public class WebApp extends BaseActivity {
         String modifiedUrl = originalUri.toString() + separator + "campaign_id=" +
                 campaignId;
         return modifiedUrl;
+    }
+
+    private String addContainerAppVersionToUrl(String appUrl) {
+        Uri originalUri = Uri.parse(appUrl);
+        String separator = (originalUri.getQuery() == null) ? "?" : "&";
+        return originalUri.toString() + separator + "container_app_version=" + BuildConfig.VERSION_NAME;
     }
 
     private boolean isInternetConnected(Context context) {


### PR DESCRIPTION
# Changes
- Append the container's `BuildConfig.VERSION_NAME` to every sub-app URL as `?container_app_version=<version>` when the WebView is launched. New `addContainerAppVersionToUrl(...)` helper follows the same Uri-build pattern as the existing `addSourceToUrl` / `addCampaignIdToUrl` helpers.

# How to test
- Build a debug APK from Android Studio (or `./gradlew assembleDebug`).
- Install on emulator/device, tap any sub-app tile, and inspect logcat for the `subapp url : ...` log line at `WebApp.java:163`. Confirm it contains `&container_app_version=<the installed APK's versionName>`.

Ref: [MR-83](https://curiouslearning.atlassian.net/browse/MR-83)


[MR-83]: https://curiouslearning.atlassian.net/browse/MR-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ