### PR TITLE
feat: [MR-97] store sub-app version and container_app_version in payload metadata

### DIFF
--- a/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
+++ b/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
@@ -54,9 +54,13 @@ public class DefaultAppEventPayloadHandler
 
         payload.collection = normalizedCollection;
 
-        if (payload.data instanceof Map) {
-            ((Map<String, Object>) payload.data).put("container_version", BuildConfig.VERSION_NAME);
+        // Stamp the container build version into metadata (not data), using the
+        // `container_app_version` naming shared with the WebView URL param and the
+        // Firebase user property set by the sub-apps.
+        if (payload.metadata == null) {
+            payload.metadata = new HashMap<>();
         }
+        payload.metadata.put("container_app_version", BuildConfig.VERSION_NAME);
 
         switch (normalizedCollection) {
 
@@ -121,6 +125,7 @@ public class DefaultAppEventPayloadHandler
         record.put("collection", payload.collection);
         record.put("created_at", Instant.now().toString());
         record.put("schema_version", payload.schema_version != null ? payload.schema_version : "unknown");
+        record.put("metadata", payload.metadata);
 
         Map<String, Object> data =
                 new HashMap<>((Map<String, Object>) payload.data);
@@ -153,6 +158,7 @@ public class DefaultAppEventPayloadHandler
         Map<String, Object> record = new HashMap<>();
         record.put("cr_user_id", payload.cr_user_id);
         record.put("app_id", payload.app_id);
+        record.put("metadata", payload.metadata);
 
         query.get()
                 .addOnSuccessListener(querySnapshot -> {

--- a/app/src/main/java/org/curiouslearning/container/core/subapp/payload/AppEventPayload.java
+++ b/app/src/main/java/org/curiouslearning/container/core/subapp/payload/AppEventPayload.java
@@ -9,6 +9,7 @@ public class AppEventPayload {
     public String collection;
     public Object data;
     public Map<String, String> options;
+    public Map<String, Object> metadata;
     public String timestamp;
     public String schema_version;
 }


### PR DESCRIPTION
# Changes
- AppEventPayload gains an optional metadata map (Gson-deserialized, validator leaves it untouched).
- Handler stamps the container build version into metadata.container_app_version (BuildConfig.VERSION_NAME) — renamed from container_version and moved out of data to match the Firebase user property / URL param naming.
- metadata is now persisted as a top-level Firestore field for both user_sessions_data and summary_data (new-doc and upsert/merge branches); mergeData() still only touches data.

# How to test
- Manual e2e (debug build, sub-app local dev server): complete an FTM level / an assessment and confirm the Firestore doc has top-level metadata: { appVersion, container_app_version } and no container_version inside data.

Ref: [MR-97](https://curiouslearning.atlassian.net/browse/MR-97)


[MR-97]: https://curiouslearning.atlassian.net/browse/MR-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ