### PR TITLE
fix: [MR-129] fix for silent crash in FTM when going offline mode

### DIFF
--- a/app/src/main/java/org/curiouslearning/container/WebApp.java
+++ b/app/src/main/java/org/curiouslearning/container/WebApp.java
@@ -246,7 +246,7 @@ public class WebApp extends BaseActivity {
             editor.putBoolean(String.valueOf(urlIndex), dataCachedStatus);
             editor.commit();
 
-            if (!isInternetConnected(getApplicationContext()) && dataCachedStatus) {
+            if (!isInternetConnected(getApplicationContext()) && !dataCachedStatus) {
                 showPrompt("Please Connect to the Network");
             }
         }


### PR DESCRIPTION
# Changes
- Changed condition when checking of cached content when offline

# How to test
- Cache any language of FTM then close the app then go offline and open FTM with cached language

Ref: [MR-129](https://curiouslearning.atlassian.net/browse/MR-129)


[MR-129]: https://curiouslearning.atlassian.net/browse/MR-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed offline connectivity messaging logic. The application now correctly displays a network connection prompt when the device is offline and cached data is unavailable. This ensures users receive accurate and timely information about their connectivity status and whether local cached data is available for use, improving the overall offline user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->