### PR TITLE
fix: jacoco config for coverage report, app_info.version removal from…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,16 @@ android {
         buildConfig = true
     }
 
+    testOptions {
+        unitTests.all { test ->
+            jacoco {
+                includeNoLocationClasses = true
+                excludes = ['jdk.internal.*']
+                destinationFile = file("$buildDir/jacoco/${test.name}.exec")
+            }
+        }
+    }
+
     signingConfigs {
         release {
             storeFile file("keystore/my-release-key.jks")
@@ -162,7 +172,7 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
     }
 
     classDirectories.setFrom(fileTree(
-            dir: "$buildDir/intermediates/classes/debug",
+            dir: "$buildDir/intermediates/classes/debug/transformDebugClassesWithAsm/dirs",
             excludes: [
                     '**/R.class',
                     '**/R$*.class',
@@ -178,27 +188,10 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
     ))
 
     sourceDirectories.setFrom(files(coverageSourceDirs))
-    executionData.setFrom(fileTree(dir: "$buildDir", includes: [
-            "jacoco/testDebugUnitTest.exec",
-            "outputs/code-coverage/connected/*coverage.ec"
-    ]))
-
-    doFirst {
-        classDirectories.setFrom(
-                files(classDirectories.files.collect {
-                    fileTree(dir: it, excludes: [
-                            '**/R.class',
-                            '**/R$*.class',
-                            '**/BuildConfig.*',
-                            '**/Manifest*.*',
-                            '**/*Test*.*',
-                            '**/databinding/*',
-                            '**/android/databinding/*',
-                            '**/androidx/**'
-                    ])
-                })
-        )
-    }
+    executionData.setFrom(files(
+            "$buildDir/jacoco/testDebugUnitTest.exec",
+            "$buildDir/outputs/code-coverage/connected/*coverage.ec"
+    ))
 }
 
 

--- a/app/src/test/java/org/curiouslearning/container/AnalyticsUtilsCustomEventsTest.java
+++ b/app/src/test/java/org/curiouslearning/container/AnalyticsUtilsCustomEventsTest.java
@@ -174,7 +174,6 @@ public class AnalyticsUtilsCustomEventsTest {
             verify(spyFA).logEvent(eq("joined_study"), captor.capture());
             Bundle b = captor.getValue();
             assertEquals("Nepali", b.getString("cr_language"));
-            assertEquals("2.34.3", b.getString("app_info.version"));
             assertEquals("12345", b.getString("cr_user_id"));
             assertEquals("test_source", b.getString("source"));
             assertEquals("test_campaign", b.getString("campaign_id"));


### PR DESCRIPTION
# Changes
- Fix Jacoco configuration for coverage reports

# How to test
- By running .\gradlew :app:jacocoTestReport
- The task is defined in build.gradle

Ref: [AJ-706](https://curiouslearning.atlassian.net/browse/AJ-706)


[AJ-706]: https://curiouslearning.atlassian.net/browse/AJ-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test coverage reporting so unit and device coverage data is collected more reliably.
  * Improved how coverage reports are generated from transformed debug classes.
* **Tests**
  * Relaxed one analytics test assertion to reduce dependency on a specific app version value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->