### PR TITLE
fix: [MR-130] sync Firestore data on container open via shared handler instance

### DIFF
--- a/app/src/main/java/org/curiouslearning/container/MainActivity.java
+++ b/app/src/main/java/org/curiouslearning/container/MainActivity.java
@@ -35,6 +35,7 @@ import com.google.android.material.textfield.TextInputLayout;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
+import org.curiouslearning.container.core.subapp.handler.DefaultAppEventPayloadHandler;
 import org.curiouslearning.container.data.model.WebApp;
 import org.curiouslearning.container.databinding.ActivityMainBinding;
 import org.curiouslearning.container.firebase.AnalyticsUtils;
@@ -98,6 +99,9 @@ public class MainActivity extends BaseActivity {
     private String manifestVersion;
     private static final String TAG = "MainActivity";
     private AudioPlayer audioPlayer;
+    // Warms Firestore and attaches summary_data sync listeners on container open (shared instance also used
+    // by WebApp). The static getInstance holds the canonical reference; this field is kept for readability.
+    private DefaultAppEventPayloadHandler summaryHandler;
     private String appVersion;
     private boolean isReferrerHandled;
     private boolean isAttributionComplete = false;
@@ -257,6 +261,7 @@ public class MainActivity extends BaseActivity {
         handleIncomingIntent(getIntent());
         audioPlayer = new AudioPlayer();
         FirebaseApp.initializeApp(this);
+        warmFirestoreDataSync();
         FacebookSdk.setAutoInitEnabled(true);
         FacebookSdk.fullyInitialize();
         FacebookSdk.setAdvertiserIDCollectionEnabled(true);
@@ -752,6 +757,10 @@ public class MainActivity extends BaseActivity {
         }
     }
 
+    private void warmFirestoreDataSync() {
+        String pseudoId = prefs.getString("pseudoId", "");
+        summaryHandler = DefaultAppEventPayloadHandler.getInstance(pseudoId);
+    }
     public static String convertEpochToDate(long epochMillis) {
         Date date = new Date(epochMillis);
         SimpleDateFormat sdf = new SimpleDateFormat("dd MMM yyyy hh:mm a", Locale.getDefault());

--- a/app/src/main/java/org/curiouslearning/container/WebApp.java
+++ b/app/src/main/java/org/curiouslearning/container/WebApp.java
@@ -237,7 +237,9 @@ public class WebApp extends BaseActivity {
 
         WebAppInterface(Context context) {
             mContext = context;
-            handler = new DefaultAppEventPayloadHandler(pseudoId);
+            // Shared process-level instance (also warmed on container open in MainActivity) — reused here so
+            // there is exactly one sync listener per summary doc across the container and all sub-apps.
+            handler = DefaultAppEventPayloadHandler.getInstance(pseudoId);
         }
 
         @JavascriptInterface

--- a/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
+++ b/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
@@ -32,9 +32,43 @@ public class DefaultAppEventPayloadHandler
     private final Map<String, ListenerRegistration> syncListeners = new HashMap<>();
     private final String crUserId;
 
+    // Process-level shared instance so the container (MainActivity) and every sub-app (WebApp) resolve to
+    // one handler. A single syncListeners map makes the per-doc dedup guard in attachSyncListener effective
+    // process-wide (exactly one sync listener per summary doc), and lets MainActivity warm Firestore /
+    // attach listeners on container open, before any sub-app is launched.
+    private static DefaultAppEventPayloadHandler instance;
+
+    /**
+     * Returns the shared handler for {@code crUserId}, constructing it on first use. Rebuilds (detaching the
+     * previous instance's listeners) only when the id changes — which in practice happens only under the
+     * DEBUG {@code custom_cr_user_id} override; the production {@code pseudoId} is stable for the process.
+     */
+    public static synchronized DefaultAppEventPayloadHandler getInstance(@NonNull String crUserId) {
+        if (instance == null || !instance.crUserId.equals(crUserId)) {
+            if (instance != null) {
+                instance.detachListeners();
+            }
+            instance = new DefaultAppEventPayloadHandler(crUserId);
+        }
+        return instance;
+    }
+
     public DefaultAppEventPayloadHandler(@NonNull String crUserId) {
         this.crUserId = crUserId;
         attachExistingSyncListeners();
+    }
+
+    /**
+     * Removes any active sync listeners and clears the registry. Used when the shared instance is replaced
+     * for a new {@code crUserId} so stale registrations are not leaked.
+     */
+    private void detachListeners() {
+        for (ListenerRegistration reg : syncListeners.values()) {
+            if (reg != null) {
+                reg.remove();
+            }
+        }
+        syncListeners.clear();
     }
 
     private void attachExistingSyncListeners() {


### PR DESCRIPTION
# Changes
- Warm Firestore when the container (`MainActivity`) opens: `warmFirestoreDataSync()` runs after Firebase init and performs the first real Firestore use on launch, so queued offline writes (both `summary_data` and `user_sessions_data`) flush and `summary_data` sync listeners attach up front — without waiting for a sub-app to be opened.
- Convert `DefaultAppEventPayloadHandler` to a shared process-level instance via `getInstance(crUserId)`, reused by both `MainActivity` and `WebApp` instead of each constructing its own. This yields exactly one sync listener per `summary_data` doc across the container and all sub-apps, fixing the pre-existing duplicate listeners created on every sub-app open.
- Add `detachListeners()` to drop stale registrations when the shared instance is rebuilt for a new `cr_user_id`.
- Existing blank-`cr_user_id` guard and offline query-failure handling are unchanged, so a missing id or offline device still degrades gracefully; the existing handler constructor is retained (unit test unaffected).

# How to test
- Offline-sync-on-container-open (primary):
  1. Open a sub-app online once so a `summary_data` doc exists.
  2. Go offline, play to queue writes, then close the app.
  3. Go online and open **only the container** (do not enter a sub-app).
- No regression: open a sub-app afterward and confirm `user_sessions_data` / `summary_data` writes and `synced_at` stamping still work.
- Graceful degradation: launch with a blank `pseudoId` and while offline — no crash; blank-id warning / read-failure logged and app continues.


Ref: [MR-130](https://curiouslearning.atlassian.net/browse/MR-130)


[MR-130]: https://curiouslearning.atlassian.net/browse/MR-130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved background data syncing so app and embedded experiences reuse a shared listener instead of creating duplicates.
  * Added earlier initialization of sync-related state when the app starts.

* **Bug Fixes**
  * Reduced the chance of repeated updates or redundant syncing for the same account.
  * Improved stability when switching between users by refreshing sync listeners appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->