### PR TITLE
fix: [MR-156] capture user country via ipinfo and stamp it into Firestore metadata

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,9 @@ android {
         ndk {
             abiFilters "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
         }
+
+        // ipinfo.io Lite token — same public token shipped in the assessment-survey-js web bundle
+        buildConfigField "String", "IPINFO_TOKEN", "\"b6268727178610\""
     }
 
     buildFeatures {

--- a/app/src/main/java/org/curiouslearning/container/MyApplication.java
+++ b/app/src/main/java/org/curiouslearning/container/MyApplication.java
@@ -4,6 +4,8 @@ import android.app.Application;
 import com.facebook.FacebookSdk;
 import com.facebook.appevents.AppEventsLogger;
 
+import org.curiouslearning.container.utilities.CountryProvider;
+
 import io.sentry.android.core.SentryAndroid;
 
 public class MyApplication extends Application {
@@ -27,5 +29,9 @@ public class MyApplication extends Application {
         });
         // RiveInitializer is auto-initialized via AndroidManifest.xml (InitializationProvider)
 
+        // MR-156: load the cached country and refresh it when the 7-day TTL lapses,
+        // so the payload handler can stamp metadata.country with no event-time I/O.
+        CountryProvider.init(this);
+        CountryProvider.refreshCountryIfStale(this);
     }
 }

--- a/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
+++ b/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
@@ -15,6 +15,7 @@ import com.google.firebase.firestore.Query;
 
 import org.curiouslearning.container.BuildConfig;
 import org.curiouslearning.container.core.subapp.payload.AppEventPayload;
+import org.curiouslearning.container.utilities.CountryProvider;
 
 import java.time.Instant;
 import java.util.HashMap;
@@ -130,6 +131,12 @@ public class DefaultAppEventPayloadHandler
             payload.metadata = new HashMap<>();
         }
         payload.metadata.put("container_app_version", BuildConfig.VERSION_NAME);
+
+        // MR-156: stamp the cached coarse country (full English name); "unknown"
+        // when the device has never resolved one.
+        String country = CountryProvider.getCountry();
+        payload.metadata.put("country",
+                country != null ? country : CountryProvider.MISSING_COUNTRY_VALUE);
 
         switch (normalizedCollection) {
 

--- a/app/src/main/java/org/curiouslearning/container/data/model/IpInfoResponse.java
+++ b/app/src/main/java/org/curiouslearning/container/data/model/IpInfoResponse.java
@@ -1,0 +1,13 @@
+package org.curiouslearning.container.data.model;
+
+/**
+ * Response model for the ipinfo.io Lite endpoint (https://api.ipinfo.io/lite/me).
+ *
+ * Deliberately declares ONLY the country field: Gson discards every other field
+ * in the response (ip, asn, continent, ...), so the device IP is never
+ * materialized, logged, or persisted (MR-156 AC 2).
+ */
+public class IpInfoResponse {
+
+    public String country;
+}

--- a/app/src/main/java/org/curiouslearning/container/data/remote/ApiService.java
+++ b/app/src/main/java/org/curiouslearning/container/data/remote/ApiService.java
@@ -2,16 +2,23 @@ package org.curiouslearning.container.data.remote;
 
 import com.google.gson.JsonElement;
 
+import org.curiouslearning.container.data.model.IpInfoResponse;
 import org.curiouslearning.container.data.model.WebApp;
 import org.curiouslearning.container.data.model.WebAppResponse;
 
 import java.util.List;
 import retrofit2.Call;
 import retrofit2.http.GET;
+import retrofit2.http.Query;
 
 public interface ApiService {
 
     @GET("web_app_manifest.json")
     Call<JsonElement> getWebApps();
+
+    // Absolute URL overrides the manifest baseUrl; Lite endpoint returns the
+    // full English country name and no city/region/coordinates.
+    @GET("https://api.ipinfo.io/lite/me")
+    Call<IpInfoResponse> getIpInfo(@Query("token") String token);
 
 }

--- a/app/src/main/java/org/curiouslearning/container/data/remote/RetrofitInstance.java
+++ b/app/src/main/java/org/curiouslearning/container/data/remote/RetrofitInstance.java
@@ -9,6 +9,7 @@ import com.google.gson.reflect.TypeToken;
 
 import org.curiouslearning.container.BuildConfig;
 import org.curiouslearning.container.data.database.WebAppDatabase;
+import org.curiouslearning.container.data.model.IpInfoResponse;
 import org.curiouslearning.container.data.model.WebApp;
 import org.curiouslearning.container.data.model.WebAppResponse;
 import org.curiouslearning.container.utilities.CacheUtils;
@@ -47,6 +48,35 @@ public class RetrofitInstance {
 
     public interface FetchCallback {
         void onComplete();
+    }
+
+    public interface CountryCallback {
+        void onSuccess(String rawCountry);
+
+        void onFailure();
+    }
+
+    public void fetchCountry(CountryCallback callback) {
+        ApiService api = retrofit.create(ApiService.class);
+        Call<IpInfoResponse> call = api.getIpInfo(BuildConfig.IPINFO_TOKEN);
+
+        call.enqueue(new Callback<IpInfoResponse>() {
+            @Override
+            public void onResponse(Call<IpInfoResponse> call, Response<IpInfoResponse> response) {
+                // Never log the response body here — it contains the device IP (MR-156 AC 2).
+                if (response.isSuccessful() && response.body() != null) {
+                    callback.onSuccess(response.body().country);
+                } else {
+                    callback.onFailure();
+                }
+            }
+
+            @Override
+            public void onFailure(Call<IpInfoResponse> call, Throwable t) {
+                Log.w("CountryProvider", "country lookup failed: " + t.getMessage());
+                callback.onFailure();
+            }
+        });
     }
 
     public void getAppManifest(WebAppDatabase webAppDatabase, FetchCallback callback) {

--- a/app/src/main/java/org/curiouslearning/container/utilities/CountryProvider.java
+++ b/app/src/main/java/org/curiouslearning/container/utilities/CountryProvider.java
@@ -1,0 +1,114 @@
+package org.curiouslearning.container.utilities;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import androidx.annotation.VisibleForTesting;
+
+import org.curiouslearning.container.data.remote.RetrofitInstance;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Resolves and caches the user's coarse "country" value (full English name,
+ * e.g. "Philippines") via the ipinfo.io Lite endpoint (MR-156).
+ *
+ * The value is cached per installation in SharedPreferences and mirrored in a
+ * volatile in-memory field so {@link #getCountry()} can be called with no
+ * Context and no I/O at event time. Only the country name is ever persisted —
+ * the device IP is never stored or logged.
+ */
+public class CountryProvider {
+
+    private static final String TAG = "CountryProvider";
+
+    // Same prefs file MainActivity uses for pseudoId.
+    private static final String PREFS_NAME = "appCached";
+    private static final String KEY_CACHED_COUNTRY = "cachedCountry";
+    private static final String KEY_CACHED_COUNTRY_UPDATED_AT = "cachedCountryUpdatedAt";
+
+    public static final String MISSING_COUNTRY_VALUE = "unknown";
+    private static final long REFRESH_TTL_MS = 7L * 24 * 60 * 60 * 1000;
+
+    private static volatile String cachedCountry;
+    private static final AtomicBoolean inFlight = new AtomicBoolean(false);
+
+    private CountryProvider() {
+    }
+
+    public static void init(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        cachedCountry = prefs.getString(KEY_CACHED_COUNTRY, null);
+    }
+
+    /**
+     * Attempts a background refresh when no value is cached or the cached value
+     * is older than the 7-day TTL. Offline or failed refreshes leave the
+     * previously cached value untouched.
+     */
+    public static void refreshCountryIfStale(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        long updatedAt = prefs.getLong(KEY_CACHED_COUNTRY_UPDATED_AT, 0L);
+        boolean fresh = cachedCountry != null
+                && (System.currentTimeMillis() - updatedAt) < REFRESH_TTL_MS;
+        if (fresh) {
+            return;
+        }
+
+        if (!ConnectionUtils.getInstance().isInternetConnected(context)) {
+            return;
+        }
+
+        if (!inFlight.compareAndSet(false, true)) {
+            return;
+        }
+
+        RetrofitInstance.getInstance().fetchCountry(new RetrofitInstance.CountryCallback() {
+            @Override
+            public void onSuccess(String rawCountry) {
+                inFlight.set(false);
+                String normalized = normalizeCountry(rawCountry);
+                if (normalized == null) {
+                    Log.w(TAG, "country lookup returned no usable country value");
+                    return;
+                }
+                cachedCountry = normalized;
+                prefs.edit()
+                        .putString(KEY_CACHED_COUNTRY, normalized)
+                        .putLong(KEY_CACHED_COUNTRY_UPDATED_AT, System.currentTimeMillis())
+                        .apply();
+                Log.d(TAG, "country cached: " + normalized);
+            }
+
+            @Override
+            public void onFailure() {
+                inFlight.set(false);
+                Log.w(TAG, "country refresh failed; keeping previously cached value");
+            }
+        });
+    }
+
+    /**
+     * Returns the cached full English country name, or null if never resolved.
+     * Reads only the in-memory field — safe to call at event time offline.
+     */
+    public static String getCountry() {
+        return cachedCountry;
+    }
+
+    @VisibleForTesting
+    static String normalizeCountry(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        String trimmed = raw.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    @VisibleForTesting
+    static void resetForTest() {
+        cachedCountry = null;
+        inFlight.set(false);
+    }
+}


### PR DESCRIPTION
# Changes
- Resolve the user's coarse "country" (full English name, e.g. "Philippines") via the ipinfo.io Lite endpoint, cached per-installation in SharedPreferences and refreshed at app launch only when no value is cached or the cached value is older than 7 days and the device is online. A failed or offline refresh never clears a previously cached value.
- Stamp `metadata.country` on every Firestore `summary_data` and `user_sessions_data` write, alongside the existing `container_app_version` stamp defaults to `"unknown"` when the device has never resolved a country.
- Device IP is never persisted or logged anywhere: the ipinfo response model (`IpInfoResponse`) declares only a `country` field, so Gson discards the IP before it's ever materialized in memory.

# How to test
- Fresh install, online: launch the app, check logcat for tag `CountryProvider` showing a successful cache write, then trigger a sub-app event (e.g. complete an FTM level) and confirm the resulting `summary_data`/`user_sessions_data` Firestore docs carry `metadata.country`.
- Airplane mode with a previously cached country: relaunch and trigger an event `metadata.country` should still be the cached value, with no network call at event time.
- Fresh install + airplane mode (no cache ever resolved): trigger an event `metadata.country` should be `"unknown"`, and event collection should proceed normally.
- Cached value present + ipinfo unreachable (e.g. block `api.ipinfo.io`) on relaunch: confirm the previously cached country is retained rather than cleared.

Ref: [MR-156](https://curiouslearning.atlassian.net/browse/MR-156)


[MR-156]: https://curiouslearning.atlassian.net/browse/MR-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App metadata now includes the device’s coarse country when available.
  * Country information is cached and refreshed periodically, including offline-safe fallback behavior.
  * Country detection uses a limited response containing only country information; device IP details are not retained.
* **Bug Fixes**
  * Payloads now consistently include a country value, using “unknown” when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->