### PR TITLE
fix: [MR-162] enrich sub-app payloads with attribution context

### DIFF
--- a/app/src/main/java/org/curiouslearning/container/MainActivity.java
+++ b/app/src/main/java/org/curiouslearning/container/MainActivity.java
@@ -164,6 +164,7 @@ public class MainActivity extends BaseActivity {
         if (!selectedLanguage.isEmpty()) {
             AppContext.getInstance().set(AppContextKey.LANGUAGE, selectedLanguage);
         }
+        hydrateAttributionContext();
         initialSlackAlertTime = AnalyticsUtils.getCurrentEpochTime();
         homeViewModal = new HomeViewModal((Application) getApplicationContext(), this);
         cachePseudoId();
@@ -217,6 +218,8 @@ public class MainActivity extends BaseActivity {
                         installReferrerEditor.putString("source", source);
                         installReferrerEditor.putString("campaign_id", campaign_id);
                         installReferrerEditor.apply();
+
+                        hydrateAttributionContext();
 
                         // Now check offline mode and log event with the stored UTM params
                         if (!isInternetConnected(getApplicationContext())) {
@@ -714,6 +717,7 @@ public class MainActivity extends BaseActivity {
                     storeSelectLanguage(lang);
                     isAttributionComplete = true;
                     AnalyticsUtils.storeReferrerParams(MainActivity.this, source, campaign_id);
+                    hydrateAttributionContext();
 
                     if (isAttributionComplete) {
                         AnalyticsUtils.logLanguageSelectEvent(MainActivity.this, "language_selected", pseudoId, lang,
@@ -1186,6 +1190,18 @@ public class MainActivity extends BaseActivity {
                 }
             }
         });
+    }
+
+    private void hydrateAttributionContext() {
+        SharedPreferences installReferrerPrefs = getSharedPreferences("InstallReferrerPrefs", MODE_PRIVATE);
+        String source = installReferrerPrefs.getString("source", "");
+        String campaignId = installReferrerPrefs.getString("campaign_id", "");
+        if (source != null && !source.trim().isEmpty()) {
+            AppContext.getInstance().set(AppContextKey.SOURCE, source);
+        }
+        if (campaignId != null && !campaignId.trim().isEmpty()) {
+            AppContext.getInstance().set(AppContextKey.CAMPAIGN_ID, campaignId);
+        }
     }
 
     private void storeSelectLanguage(String language) {

--- a/app/src/main/java/org/curiouslearning/container/MainActivity.java
+++ b/app/src/main/java/org/curiouslearning/container/MainActivity.java
@@ -1196,12 +1196,11 @@ public class MainActivity extends BaseActivity {
         SharedPreferences installReferrerPrefs = getSharedPreferences("InstallReferrerPrefs", MODE_PRIVATE);
         String source = installReferrerPrefs.getString("source", "");
         String campaignId = installReferrerPrefs.getString("campaign_id", "");
-        if (source != null && !source.trim().isEmpty()) {
-            AppContext.getInstance().set(AppContextKey.SOURCE, source);
-        }
-        if (campaignId != null && !campaignId.trim().isEmpty()) {
-            AppContext.getInstance().set(AppContextKey.CAMPAIGN_ID, campaignId);
-        }
+        AppContext context = AppContext.getInstance();
+        context.set(AppContextKey.SOURCE,
+            source == null || source.trim().isEmpty() ? "" : source.trim());
+        context.set(AppContextKey.CAMPAIGN_ID,
+            campaignId == null || campaignId.trim().isEmpty() ? "" : campaignId.trim());
     }
 
     private void storeSelectLanguage(String language) {

--- a/app/src/main/java/org/curiouslearning/container/WebApp.java
+++ b/app/src/main/java/org/curiouslearning/container/WebApp.java
@@ -26,6 +26,8 @@ import org.curiouslearning.container.utilities.ConnectionUtils;
 import org.curiouslearning.container.utilities.AudioPlayer;
 import io.sentry.Sentry;
 
+import org.curiouslearning.container.core.context.AppContext;
+import org.curiouslearning.container.core.context.AppContextKey;
 import org.curiouslearning.container.core.subapp.payload.AppEventPayload;
 import org.curiouslearning.container.core.subapp.validation.AppEventPayloadValidator;
 import org.curiouslearning.container.core.subapp.validation.ValidationResult;
@@ -77,6 +79,10 @@ public class WebApp extends BaseActivity {
             appUrl = intent.getStringExtra("appUrl");
             language = intent.getStringExtra("language");
             languageInEnglishName = intent.getStringExtra("languageInEnglishName");
+
+            String host = (appUrl != null) ? Uri.parse(appUrl).getHost() : null;
+            AppContext.getInstance().set(AppContextKey.HOSTNAME,
+                    (host != null && !host.isEmpty()) ? host : "unknown");
         }
     }
 

--- a/app/src/main/java/org/curiouslearning/container/core/context/AppContextKey.java
+++ b/app/src/main/java/org/curiouslearning/container/core/context/AppContextKey.java
@@ -5,5 +5,8 @@ package org.curiouslearning.container.core.context;
  * here rather than introducing separate constants elsewhere.
  */
 public enum AppContextKey {
-    LANGUAGE
+    LANGUAGE,
+    CAMPAIGN_ID,
+    SOURCE,
+    HOSTNAME
 }

--- a/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
+++ b/app/src/main/java/org/curiouslearning/container/core/subapp/handler/DefaultAppEventPayloadHandler.java
@@ -140,6 +140,14 @@ public class DefaultAppEventPayloadHandler
         payload.metadata.put("country",
                 country != null ? country : CountryProvider.MISSING_COUNTRY_VALUE);
 
+        if (payload.attribution == null) {
+            payload.attribution = new HashMap<>();
+        }
+        payload.attribution.put("campaign_id", resolveContextString(AppContextKey.CAMPAIGN_ID, ""));
+        payload.attribution.put("source", resolveContextString(AppContextKey.SOURCE, ""));
+        payload.attribution.put("hostname", resolveContextString(AppContextKey.HOSTNAME, "unknown"));
+        payload.attribution.put("apk_package_name", BuildConfig.APPLICATION_ID);
+
         switch (normalizedCollection) {
 
             case COLLECTION_USER_SESSION:
@@ -212,6 +220,7 @@ public class DefaultAppEventPayloadHandler
         record.put("created_at", Instant.now().toString());
         record.put("schema_version", payload.schema_version != null ? payload.schema_version : "unknown");
         record.put("metadata", payload.metadata);
+        record.put("attribution", payload.attribution);
 
         Map<String, Object> data =
                 new HashMap<>((Map<String, Object>) payload.data);
@@ -235,12 +244,16 @@ public class DefaultAppEventPayloadHandler
      * initialized), so event storage never fails solely because the language is unavailable.
      */
     private String resolveLanguage() {
+        return resolveContextString(AppContextKey.LANGUAGE, "unknown");
+    }
+
+    private String resolveContextString(AppContextKey key, String fallback) {
         try {
-            String lang = AppContext.getInstance().get(AppContextKey.LANGUAGE);
-            return (lang != null && !lang.trim().isEmpty()) ? lang : "unknown";
+            String value = AppContext.getInstance().get(key);
+            return (value != null && !value.trim().isEmpty()) ? value : fallback;
         } catch (Exception e) {
-            Log.w(TAG, "Language unavailable for enrichment — defaulting to \"unknown\"", e);
-            return "unknown";
+            Log.w(TAG, "AppContext value unavailable for " + key + " — defaulting to \"" + fallback + "\"", e);
+            return fallback;
         }
     }
 
@@ -275,6 +288,7 @@ public class DefaultAppEventPayloadHandler
         record.put("cr_user_id", payload.cr_user_id);
         record.put("app_id", payload.app_id);
         record.put("metadata", payload.metadata);
+        record.put("attribution", payload.attribution);
         record.put("data", dataWriteMap);
 
         query.get()

--- a/app/src/main/java/org/curiouslearning/container/core/subapp/payload/AppEventPayload.java
+++ b/app/src/main/java/org/curiouslearning/container/core/subapp/payload/AppEventPayload.java
@@ -10,6 +10,7 @@ public class AppEventPayload {
     public Object data;
     public Map<String, String> options;
     public Map<String, Object> metadata;
+    public Map<String, Object> attribution;
     public String timestamp;
     public String schema_version;
 }


### PR DESCRIPTION
# Changes
- Added an `attribution` block to every enriched sub-app payload, carrying `campaign_id`, `source`, `hostname`, and `apk_package_name`. It is written to both `user_sessions_data` and `summary_data` Firestore records.
- Introduced `hydrateAttributionContext()` in `MainActivity`, populating `AppContext` (`SOURCE`, `CAMPAIGN_ID`) from `InstallReferrerPrefs` hydrated on create, after install-referrer resolution, and on language selection.
- `WebApp` now derives `HOSTNAME` from the launched sub-app URL (falling back to `"unknown"`) and stores it in `AppContext`.
- Extended `AppContextKey` with `CAMPAIGN_ID`, `SOURCE`, and `HOSTNAME`; added the `attribution` map field to `AppEventPayload`.
- Attribution/context reads are wrapped in a safe resolver missing or uninitialized `AppContext` values fall back to defaults so event storage never fails on absent enrichment data.

# How to test
- Manual: launch a sub-app (e.g. Feed The Monster) with a UTM/campaign install referrer set, complete a level, and verify in Firestore that:
  - `user_sessions_data` documents contain an `attribution` block (`campaign_id`, `source`, `hostname`, `apk_package_name`) and `metadata.language`.
  - `summary_data` documents contain the `attribution` block.
- Verify `hostname` resolves from the sub-app URL and defaults to `"unknown"` when the URL is missing.


Ref: [MR-162](https://curiouslearning.atlassian.net/browse/MR-162)


[MR-162]: https://curiouslearning.atlassian.net/browse/MR-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added attribution context support for campaign, source, hostname, and app package details.
  - Hydrates attribution from install referrer and deferred app links, and derives hostname from app URL.
  - Enriches stored event payloads with attribution data, including user session events.
  - Adds an attribution field to event payloads and resolves language with safe fallback values when unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->